### PR TITLE
Update httpclient.js 解决 chrome 打开新创被拦截的问题

### DIFF
--- a/assets/bootstrap/js/httpclient/httpclient.js
+++ b/assets/bootstrap/js/httpclient/httpclient.js
@@ -44,10 +44,9 @@ function AjaxError(response) {
     let errCode = response.status;
     let errMsg = response.responseText;
 
-    if (errCode === 401) { // 跳转到登录页
-        // 关闭当前界面
-        parent.window.close();
-        window.open("/login");
+    if (errCode === 401) {
+        // 跳转到登录页
+        window.open("/login",'_self');
         return;
     }
 


### PR DESCRIPTION
解决 chrome 打开新创被拦截的问题
参考 https://blog.csdn.net/oscar999/article/details/124505724